### PR TITLE
feat: Add `minimum_box_area_ratio` to filter out poor, partial boxes

### DIFF
--- a/examples/layers/preprocessing/bounding_box/jittered_resize_demo.py
+++ b/examples/layers/preprocessing/bounding_box/jittered_resize_demo.py
@@ -23,6 +23,7 @@ def main():
         target_size=(512, 512),
         scale_factor=(3 / 4, 4 / 3),
         bounding_box_format="xyxy",
+        minimum_box_area_ratio=0.5
     )
     result = dataset.map(jittered_resize, num_parallel_calls=tf.data.AUTOTUNE)
     demo_utils.visualize_data(result, bounding_box_format="xyxy")

--- a/keras_cv/src/layers/preprocessing/jittered_resize.py
+++ b/keras_cv/src/layers/preprocessing/jittered_resize.py
@@ -103,6 +103,7 @@ class JitteredResize(VectorizedBaseImageAugmentationLayer):
         crop_size=None,
         bounding_box_format=None,
         interpolation="bilinear",
+        minimum_box_area_ratio=0.0,
         seed=None,
         **kwargs,
     ):
@@ -130,6 +131,8 @@ class JitteredResize(VectorizedBaseImageAugmentationLayer):
         self.seed = seed
 
         self.force_output_dense_images = True
+        
+        self.minimum_box_area_ratio = minimum_box_area_ratio
 
     def compute_ragged_image_signature(self, images):
         ragged_spec = tf.RaggedTensorSpec(
@@ -252,6 +255,7 @@ class JitteredResize(VectorizedBaseImageAugmentationLayer):
             result,
             image_shape=self.target_size + (3,),
             bounding_box_format="yxyx",
+            minimum_box_area_ratio=self.minimum_box_area_ratio
         )
         result = bounding_box.convert_format(
             result,

--- a/keras_cv/src/layers/preprocessing/jittered_resize.py
+++ b/keras_cv/src/layers/preprocessing/jittered_resize.py
@@ -306,6 +306,7 @@ class JitteredResize(VectorizedBaseImageAugmentationLayer):
                 "crop_size": self.crop_size,
                 "bounding_box_format": self.bounding_box_format,
                 "interpolation": self.interpolation,
+                "minimum_box_area_ratio": self.minimum_box_area_ratio,
                 "seed": self.seed,
             }
         )


### PR DESCRIPTION
# What does this PR do?

This PR adds logic to the `bounding_box.clip_to_image` to attenuate the boxes that fall below a certain threshold of their original area in an image. This is particularly useful when creating a training dataset and wanting to ensure partial elements of an object that could now belong to any class e.g. a foot are not detected as a particular class leading to a noisy output during inference.

This can be tested with the jittered resize demo by setting this value to 0.95 (most boxes will be filtered out as at least 5% has been cropped / clipped out) and then setting it to 0.0 which will make it behave as before.

@divyashreepathihalli and @sampathweb

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons --sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!--
Feel free to tag @divyashreepathihalli and @sampathweb in your reviews.
-->

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
